### PR TITLE
Correção da consulta que busca os complementos

### DIFF
--- a/src/main/resources/sql/op_2_gera_xmls/pje/07_consulta_complementos.sql
+++ b/src/main/resources/sql/op_2_gera_xmls/pje/07_consulta_complementos.sql
@@ -1,17 +1,39 @@
-select
+SELECT
 	cs.id_movimento_processo,
     tc.cd_tipo_complemento, 
     tc.ds_nome,
-    cs.ds_texto AS cd_complemento,
+	CASE WHEN (tc.cd_tipo_complemento = '16') AND (pe.dt_atualizacao <  (SELECT installed_on FROM pje_adm.tb_schema_version tsv WHERE "version" LIKE '%2.2.3%' AND state = 'SUCCESS' ORDER BY installed_on DESC LIMIT 1)) 
+		 		--tipo de audiência. Até a versão 2.2.2 o PJe preenchia erroneamente o código do complemento com o id_tipo_audiencia da tb_tipo_audiencia
+				THEN  COALESCE( (SELECT cd_sigla_tipo_audiencia FROM tb_tipo_audiencia ta WHERE ta.id_tipo_audiencia::TEXT = cs.ds_texto LIMIT 1), 
+								 cs.ds_texto, '')
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Petição (outras)' THEN '57' --No TRT-7 todos os complementos estão vazios e não tem registro na tb_elemento_dominio
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Indicação de Data de Diligência Pericial' THEN '7557' --Erro na nomenclatura, que deveria ser Indicação de Data de Realização de Diligência Pericial
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Apresentação de Renúncia de Procuração' THEN '7423' --Erro na nomenclatura, que deveria ser Apresentação de Renúncia de Procuração/Substabelecimento
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Apresentação de Renúncia de Procuração' THEN '7424' --Erro na nomenclatura, que deveria ser Apresentação de Revogação de Procuração/Substabelecimento
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Requisição Antecipada de Honorários Periciais' THEN '7570' --Erro na base (cd_tipo_complemento = 19) quando deveria ser 4		 
+		 --quando vier nulo ou vazio o código no tipo de complemento dinamico, busca pelo nome na tabela elemento dominio
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND tc.tp_tipo_complemento = 'D' THEN
+		 	COALESCE (
+				 		(SELECT ed.cd_glossario FROM tb_elemento_dominio ed 
+						 	WHERE ed.id_dominio = cs.id_tipo_complemento 
+						 	  AND ed.ds_valor = cs.ds_valor_complemento LIMIT 1)
+				 	  , '')
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND tc.tp_tipo_complemento = 'L' THEN 
+			--quando vier nulo ou vazio nos tipos de complemento livre. Nesses tipos de complemento o campo tc.cd_tipo_complemento possui o mesmo valor do campo tb_dominio.cd_glossario
+			--Os complementos do tipo livre nao possuem registro na tabela tb_elemento_dominio e o complemento 5067 nao tem registro na tabela tb_dominio, por isso usar a tb_tipo_complemento.cd_tipo_complemento
+		 	COALESCE(tc.cd_tipo_complemento, '')
+		 ELSE cs.ds_texto
+     END AS cd_complemento,
     regexp_replace(cs.ds_valor_complemento, '[\r\n]', '') AS ds_valor_complemento
-from tb_complemento_segmentado cs
-inner join tb_tipo_complemento tc ON (tc.id_tipo_complemento = cs.id_tipo_complemento)
-where 1=1
-    and cs.id_movimento_processo = ANY(:id_movimento_processo)
-    and tc.cd_tipo_complemento is not null
-    and tc.ds_nome is not null
-    and
+FROM tb_complemento_segmentado cs
+INNER JOIN tb_tipo_complemento tc ON (tc.id_tipo_complemento = cs.id_tipo_complemento)
+INNER JOIN tb_processo_evento pe on (pe.id_processo_evento = cs.id_movimento_processo)
+WHERE 1=1
+    AND cs.id_movimento_processo = ANY(:id_movimento_processo)
+    AND tc.cd_tipo_complemento is not null
+    AND tc.ds_nome is not null
+    AND
     (0=1
-      or '' <> trim(cs.ds_texto) 
-      or cs.ds_valor_complemento is not null
+      OR '' <> trim(cs.ds_texto) 
+      OR cs.ds_valor_complemento is not null
     )

--- a/src/main/resources/sql/op_2_gera_xmls/pje/07_consulta_complementos.sql
+++ b/src/main/resources/sql/op_2_gera_xmls/pje/07_consulta_complementos.sql
@@ -6,34 +6,34 @@ SELECT
 		 		--tipo de audiência. Até a versão 2.2.2 o PJe preenchia erroneamente o código do complemento com o id_tipo_audiencia da tb_tipo_audiencia
 				THEN  COALESCE( (SELECT cd_sigla_tipo_audiencia FROM tb_tipo_audiencia ta WHERE ta.id_tipo_audiencia::TEXT = cs.ds_texto LIMIT 1), 
 								 cs.ds_texto, '')
-		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Petição (outras)' THEN '57' --No TRT-7 todos os complementos estão vazios e não tem registro na tb_elemento_dominio
-		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Indicação de Data de Diligência Pericial' THEN '7557' --Erro na nomenclatura, que deveria ser Indicação de Data de Realização de Diligência Pericial
-		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Apresentação de Renúncia de Procuração' THEN '7423' --Erro na nomenclatura, que deveria ser Apresentação de Renúncia de Procuração/Substabelecimento
-		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Apresentação de Renúncia de Procuração' THEN '7424' --Erro na nomenclatura, que deveria ser Apresentação de Revogação de Procuração/Substabelecimento
-		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND cs.ds_valor_complemento = 'Requisição Antecipada de Honorários Periciais' THEN '7570' --Erro na base (cd_tipo_complemento = 19) quando deveria ser 4		 
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto IS NULL)) AND cs.ds_valor_complemento = 'Petição (outras)' THEN '57' --No TRT-7 todos os complementos estão vazios e não tem registro na tb_elemento_dominio
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto IS NULL)) AND cs.ds_valor_complemento = 'Indicação de Data de Diligência Pericial' THEN '7557' --Erro na nomenclatura, que deveria ser Indicação de Data de Realização de Diligência Pericial
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto IS NULL)) AND cs.ds_valor_complemento = 'Apresentação de Renúncia de Procuração' THEN '7423' --Erro na nomenclatura, que deveria ser Apresentação de Renúncia de Procuração/Substabelecimento
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto IS NULL)) AND cs.ds_valor_complemento = 'Apresentação de Renúncia de Procuração' THEN '7424' --Erro na nomenclatura, que deveria ser Apresentação de Revogação de Procuração/Substabelecimento
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto IS NULL)) AND cs.ds_valor_complemento = 'Requisição Antecipada de Honorários Periciais' THEN '7570' --Erro na base (cd_tipo_complemento = 19) quando deveria ser 4		 
 		 --quando vier nulo ou vazio o código no tipo de complemento dinamico, busca pelo nome na tabela elemento dominio
-		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND tc.tp_tipo_complemento = 'D' THEN
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto IS NULL)) AND tc.tp_tipo_complemento = 'D' THEN
 		 	COALESCE (
 				 		(SELECT ed.cd_glossario FROM tb_elemento_dominio ed 
 						 	WHERE ed.id_dominio = cs.id_tipo_complemento 
 						 	  AND ed.ds_valor = cs.ds_valor_complemento LIMIT 1)
 				 	  , '')
-		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto is NULL)) AND tc.tp_tipo_complemento = 'L' THEN 
+		 WHEN ((cs.ds_texto = '') OR (cs.ds_texto IS NULL)) AND tc.tp_tipo_complemento = 'L' THEN 
 			--quando vier nulo ou vazio nos tipos de complemento livre. Nesses tipos de complemento o campo tc.cd_tipo_complemento possui o mesmo valor do campo tb_dominio.cd_glossario
 			--Os complementos do tipo livre nao possuem registro na tabela tb_elemento_dominio e o complemento 5067 nao tem registro na tabela tb_dominio, por isso usar a tb_tipo_complemento.cd_tipo_complemento
 		 	COALESCE(tc.cd_tipo_complemento, '')
 		 ELSE cs.ds_texto
-     END AS cd_complemento,
-    regexp_replace(cs.ds_valor_complemento, '[\r\n]', '') AS ds_valor_complemento
+	END AS cd_complemento,
+	REGEXP_REPLACE(cs.ds_valor_complemento, '[\r\n]', '') AS ds_valor_complemento
 FROM tb_complemento_segmentado cs
 INNER JOIN tb_tipo_complemento tc ON (tc.id_tipo_complemento = cs.id_tipo_complemento)
 INNER JOIN tb_processo_evento pe on (pe.id_processo_evento = cs.id_movimento_processo)
 WHERE 1=1
     AND cs.id_movimento_processo = ANY(:id_movimento_processo)
-    AND tc.cd_tipo_complemento is not null
-    AND tc.ds_nome is not null
+    AND tc.cd_tipo_complemento IS NOT null
+    AND tc.ds_nome IS NOT null
     AND
     (0=1
-      OR '' <> trim(cs.ds_texto) 
-      OR cs.ds_valor_complemento is not null
+      OR (cs.ds_texto IS NOT NULL AND TRIM(cs.ds_texto) <> '')
+      OR (cs.ds_valor_complemento IS NOT NULL AND TRIM(cs.ds_valor_complemento) <> '')
     )


### PR DESCRIPTION
Foram incluídas as seguintes alterações:

Eu fiz 4 alterações:

1) Nos movimentos anteriores à versão 2.2.3 do PJe, pegar o código do tipo de audiência da tb_tipo_audiencia (bug conhecido), verificando a tabela pje_adm.tb_schema_version tb_versao_sistema para pegar a data da atualização da versão 2.2.3. Poderia ter sido utilizada também a tb_versao_sistema, mas não temos nenhum registro nesta tabela;

2) Incluí alguns mapeamentos de documentos por inconsistência na descrição;

3) Busquei o código da  tb_elemento_dominio quando o complemento for do tipo dinâmico;

4) Usei o código da tb_tipo_complemento (cd_tipo_complemento) quando o complemento for do tipo livre (ex: 5005 do movimento 970). Os complementos do tipo livre não tem registro na tb_elemento_dominio e o correto seria pegar da  tb_dominio (cd_glossario), porém o complemento 5067 não tem registro nessa tabela e eu notei que nesses tipos de complemento o código da tb_tipo_complemento é o mesmo código do complemento.