### PR TITLE
Correção da verificação do magistrado prolator de um julgamento do processo

### DIFF
--- a/config_modelo.properties
+++ b/config_modelo.properties
@@ -49,10 +49,11 @@ sistema_judicial=APENAS_PJE
 
 # OPCIONAL: Indica a URL do "Programa validador de arquivos XML" (disponibilizado pelo CNJ para as equipes dos tribunais
 # no endereço https://www.cnj.jus.br/pesquisas-judiciarias/premio-cnj-de-qualidade/orientacoes-para-envio-via-servico-rest/ ).
-# Esse aplicativo é uma imagem Docker que permite aplicar, localmente, as mesmas validações que são aplicadas no CNJ.
+# Esse aplicativo é uma imagem Docker que permite aplicar, localmente, as mesmas validações que são aplicadas no CNJ. 
+# O parâmetro debug permite desabilitar as mensagens de log no nível debug, que em regra são desnecessárias
 # Se esse parâmetro EXISTIR, o arquivo XML só será gerado se passar no validador.
 # Se esse parâmetro NÃO EXISTIR, o arquivo XML será gerado mesmo sem validação.
-# url_validador_cnj=http://localhost:8081/v1/valida
+# url_validador_cnj=http://localhost:8081/v1/valida?debug=off
 
 
 
@@ -116,6 +117,7 @@ numero_threads_simultaneas=10
 
 
 # Descomente as linhas abaixo caso seja necessario utilizar um servidor proxy para acessar os serviços REST do CNJ.
+# Se utilizar o CNTLM ou equivalente, é possível indicar apenas o proxy_host e proxy_port. 
 # proxy_host=127.0.0.1
 # proxy_port=3129
 # proxy_username=XXX
@@ -165,9 +167,12 @@ numero_threads_simultaneas=10
 # Habilite o parâmetro abaixo para inserir assuntos padrão no processo, quando o processo não tiver
 # assunto cadastrado no PJe. Preencha o CÓDIGO do assunto, os outros dados serão consultados no
 # banco de dados do PJe.
-# No 1o Grau: 1654 - DIREITO DO TRABALHO (864) / Contrato Individual de Trabalho
-# assunto_padrao_1G=1654
-# assunto_padrao_2G=???
+# No 1o Grau: 10652 - DIREITO PROCESSUAL CIVIL E DO TRABALHO (8826) / Jurisdição e Competência (8828) / 
+#      Competência (8829) / Competência da Justiça do Trabalho (10652)
+# No 2o Grau: 10652 - DIREITO PROCESSUAL CIVIL E DO TRABALHO (8826) / Jurisdição e Competência (8828) / 
+#      Competência (8829) / Competência da Justiça do Trabalho (10652)
+# assunto_padrao_1G=10652
+# assunto_padrao_2G=10652
 
 
 
@@ -202,7 +207,7 @@ numero_threads_simultaneas=10
 # Os demais arquivos XML no caminho do legado, que não forem tiverem correspondência com processos do PJe, permanecerão inalterados e poderão
 # ser enviados como estão para validação e encaminhados para o CNJ.
 # 
-# ATENÇÃO: Essa abordagem só deve ser utiliza com o parâmetro sistema_judicial contendo o valor APENAS_PJE.
+# ATENÇÃO: Essa abordagem só deve ser utiliza com o parâmetro sistema_judicial contendo o valor APENAS_PJE_COM_MIGRADOS_LEGADO.
 # mesclar_movimentos_xml_legado_migrado = NAO
 
 

--- a/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
+++ b/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
@@ -9,7 +9,9 @@ import java.sql.Array;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -1415,18 +1417,33 @@ public class Op_2_GeraXMLsIndividuais implements Closeable {
 					
 					// Analisa a lista de sentenças e acórdãos do processo, para tentar encontrar qual o 
 					// magistrado responsável pelo movimento de julgamento
-					DocumentoDto documentoRelacionado = processo.getSentencasAcordaos().stream()
+					List<DocumentoDto> documentosRelacionados = processo.getSentencasAcordaos().stream()
 							
-						// Procura uma sentença ou acórdão ANTERIOR ao movimento para saber qual o magistrado prolator.
-						.filter(d -> d.getDataJuntada().isBefore(dataMovimento))
+						// Procura os documentos no período de tempo comprendido entre 7 dias antes do movimento e 7 dias depois.
+						.filter(d ->  d.getDataJuntada().isAfter(dataMovimento.minusDays(7))
+									&& d.getDataJuntada().isBefore(dataMovimento.plusDays(7)))
 						
-						// Volta no máximo uma semana, para evitar pegar um documento muito antigo
-						.filter(d -> d.getDataJuntada().isAfter(dataMovimento.minusDays(7)))
-						.findFirst().orElse(null);
+						// Ordena a lista pelo valor absoluto da diferença entre a data do movimento e a data do documento 
+						.sorted((d1, d2) -> Math.abs((int) Duration.between(d1.getDataJuntada(), dataMovimento).toMillis()) 
+											- Math.abs((int) Duration.between(d2.getDataJuntada(), dataMovimento).toMillis()))
+						
+						// Cria uma lista com o resultado
+						.collect(Collectors.toList());				
 					
 					// Se encontrou, preenche CPF do magistrado prolator.
-					if (documentoRelacionado != null) {
-						movimento.getMagistradoProlator().add(documentoRelacionado.getCpfUsuarioAssinou());
+					if (!documentosRelacionados.isEmpty()) {
+						movimento.getMagistradoProlator().add(documentosRelacionados.get(0).getCpfUsuarioAssinou());
+						
+						if(documentosRelacionados.size() > 1) {
+									
+							DateTimeFormatter formatadorData = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss.SSS");
+
+							LOGGER.warn(String.format("Foi encontrado mais de um documento com provável decisão para o movimento "
+												+ "com id_processo_evento %s do processo %s. O documento mais próximo e escolhido foi o com data igual a %s.", 
+									movimentoDto.getIdProcessoEvento(), processo.getNumeroProcesso(), 
+									formatadorData.format(documentosRelacionados.get(0).getDataJuntada())));
+						}
+						
 					} else {
 						LOGGER.warn(String.format("Não foi possível encontrar o magistrado prolator do movimento "
 												+ "com id_processo_evento %s do processo %s.", 

--- a/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
+++ b/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
@@ -1287,7 +1287,7 @@ public class Op_2_GeraXMLsIndividuais implements Closeable {
 			Fonte: http://www.cnj.jus.br/programas-e-acoes/pj-justica-em-numeros/selo-justica-em-numeros/perguntas-frequentes
 		 */
 		// Conversando com Clara, decidimos utilizar sempre a serventia do OJ do processo
-		ServentiaCNJ serventiaCNJ = processaServentiasCNJ.getServentiaByOJ(nomeOrgaoJulgadorProcesso, codigoOrgaoJulgadorLegado, baseEmAnalise);
+		ServentiaCNJ serventiaCNJ = processaServentiasCNJ.getServentiaByOJ(nomeOrgaoJulgadorProcesso, null, codigoOrgaoJulgadorLegado, baseEmAnalise);
 		if (serventiaCNJ == null) {
 			if (!considerarParametroMovimentosSemServentiaCnj || this.paramMovimentosSemServentiaCnj.equals(Op_2_GeraXMLsIndividuais.MOVIMENTOS_SEM_SERVENTIA_CNJ_DESCARTAR_PROCESSO)) {
 				throw new DataJudException("Falta mapear serventia no arquivo " + AnalisaServentiasCNJ.getArquivoServentias());				

--- a/src/main/resources/sql/op_2_gera_xmls/pje/09_consulta_sentencas_acordaos.sql
+++ b/src/main/resources/sql/op_2_gera_xmls/pje/09_consulta_sentencas_acordaos.sql
@@ -10,9 +10,13 @@ WHERE proc.nr_processo = ANY(:numeros_processos)
   AND doc.id_tipo_processo_documento::varchar IN (
 	SELECT vl_variavel
 	FROM tb_parametro
-	WHERE nm_variavel IN ('idTipoProcessoDocumentoAcordao', 'idTipoProcessoDocumentoSentenca')
+	WHERE nm_variavel IN ('idTipoProcessoDocumentoAcordao', 'idTipoProcessoDocumentoSentenca', 
+							'idTipoProcessoDocumentoAtaAudiencia', 'idTipoProcessoDocumentoDecisao')
   )
-
+  
+   --Não foi usado nenhum filtro de data para os documentos pois essa verificação é feita em código java
+  --considerado documentos retornados dessa consulta no período entre 7 dias antes e depois do movimento
+  
   -- Reforça a condição da data de autuação, pois um bug no PJe fez com que houvesse mais que um processo com mesma numeração (um com data de autuação e outro sem)
   AND ptrf.dt_autuacao IS NOT NULL
 


### PR DESCRIPTION
Foram feitas duas modificações principais com relação ao magistrado prolator:

- Inclusão dos documentos ata de audiência e decisão na lista de documentos na consulta SQL;
- como não há vínculo entre o movimento de julgamento e o documento, pelo menos nos documentos mais antigos, considerou o documento com data de juntada mais próxima da data do movimento, seja antes ou depois, desde que o documento esteja entre o período de 7 dias antes e 7 dias depois do movimento.

Além disso, foi incluída também a exibição no console dos números dos processos do PJe presentes em OJs sem serventia cadastradas ou com histórico de deslocamentos neles.