### PR TITLE
Correção verificação de existência de arquivos XML migrados do legado.

### DIFF
--- a/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
+++ b/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
@@ -495,7 +495,7 @@ public class Op_2_GeraXMLsIndividuais implements Closeable {
             throws JAXBException {
         File pastaXMLsLegado = Auxiliar.getPastaXMLsLegado(grau);
         List<File> listaXMLLegado = listarXMLLegadoParaProcesso(pastaXMLsLegado, operacao.numeroProcesso, ".xml");
-        if (listaXMLLegado.isEmpty()) {
+        if (!listaXMLLegado.isEmpty()) {
             LOGGER.debug("[" + operacao.numeroProcesso + "] Encontrado dados do sistema legado. O processo foi migrado para o PJe. Total de arquivos: " + listaXMLLegado.size());
             List<TipoMovimentoProcessual> movimentosLegado = new ArrayList<>();
             JAXBContext jaxbContext = JAXBContext.newInstance(Processos.class);


### PR DESCRIPTION
A verificação se existe um arquivo XML ou não parece estar equivocada, que avalia se a lista com arquivo XML está vazia, quando deveria avaliar se a lista estiver não vazia.