### PR TITLE
Permitir que todos os movimentos do legado sejam incluídos no arquivo XML.

### DIFF
--- a/config_modelo.properties
+++ b/config_modelo.properties
@@ -193,11 +193,23 @@ numero_threads_simultaneas=10
 
 
 
-# OPCIONAL: Indica se movimentos que não foram mapeados no "depara-jt-cnj" devem ser descartados ou não
+# OPCIONAL: Indica se movimentos que não foram mapeados no "depara-jt-cnj" devem ser descartados ou não. Para os movimentos do 
+# legado, esse parâmetro poderá ser desconsiderado caso o parâmetro incluir_todos_movimentos_base_legado esteja ativado.
 # O valor NAO faz com que todos os movimentos sejam incluídos, mesmo os que não forem mapeados pelo projeto "depara-jt-cnj"
 # O valor SIM faz com que somente movimentos mapeados pelo projeto "depara-jt-cnj" sejam incluídos no XML, sendo que os demais serão descartados. 
 # Valor padrão=NAO
 # descartar_movimentos_ausentes_de_para_cnj=NAO
+
+
+
+# OPCIONAL: Indica se todos os movimentos da base do legado serão incluídos ou não, independentemente se foram ou não 
+# mapeados no "depara-jt-cnj".
+# O valor NAO faz com que o movimento do legado seja descartado ou não a depender do valor do parâmetro descartar_movimentos_ausentes_de_para_cnj
+# O valor SIM faz com que todos os movimentos do legado sejam incluídos, mesmo os que não forem mapeados pelo projeto "depara-jt-cnj" 
+# Valor padrão=NAO
+#incluir_todos_movimentos_base_legado=NAO
+
+
 
 # OPCIONAL: Se o parâmetro mesclar_movimentos_xml_legado_migrado estiver com o valor SIM, ativa a mesclagem de movimentos do XML do sistema legado.
 # É esperado que os XMLs com os dados do sistema legado tenham sido gerados conforme a definição XSD vigente e estejam no caminho conhecido.

--- a/src/main/java/br/jus/trt4/justica_em_numeros_2016/auxiliar/Parametro.java
+++ b/src/main/java/br/jus/trt4/justica_em_numeros_2016/auxiliar/Parametro.java
@@ -38,6 +38,7 @@ public enum Parametro {
 	url_legado_2g,
 	sistema_judicial,
 	descartar_movimentos_ausentes_de_para_cnj,
+	incluir_todos_movimentos_base_legado,
 	mesclar_movimentos_xml_legado_migrado,
 	movimentos_sem_serventia_cnj,
 	possui_deslocamento_oj_legado_1g,

--- a/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
+++ b/src/main/java/br/jus/trt4/justica_em_numeros_2016/tasks/Op_2_GeraXMLsIndividuais.java
@@ -1384,9 +1384,14 @@ public class Op_2_GeraXMLsIndividuais implements Closeable {
 			// OBS: os complementos só existem no MovimentoNacional
 			TipoMovimentoNacional movimentoNacional = movimento.getMovimentoNacional();
 			
-			// Se o parâmetro descartar_movimentos_ausentes_de_para_cnj tiver o valor SIM, apenas movimentos mapeados no DE-PARA do CNJ serão mantidos
+			// Se o parâmetro descartar_movimentos_ausentes_de_para_cnj tiver o valor SIM, apenas movimentos mapeados 
+			// no DE-PARA do CNJ serão mantidos. No caso dos movimentos do legado, o parâmetro incluir_todos_movimentos_base_legado
+			// desconsidera o valor daquele parâmetro. 
 			boolean descartarMovimentosAusentesDeParaCNJ = Auxiliar.getParametroBooleanConfiguracao(Parametro.descartar_movimentos_ausentes_de_para_cnj, false);
-			if (!descartarMovimentosAusentesDeParaCNJ || (movimentoNacional != null)) {
+			
+			boolean incluirTodosMovimentosLegado = Auxiliar.getParametroBooleanConfiguracao(Parametro.incluir_todos_movimentos_base_legado, false);
+			if (!descartarMovimentosAusentesDeParaCNJ || (movimentoNacional != null)
+					|| (incluirTodosMovimentosLegado && baseEmAnalise.isBaseLegado())) {
 				movimentos.add(movimento);
 			} 
 


### PR DESCRIPTION
Alterações para permitir que todos os movimentos do legado sejam incluídos no arquivo XML, independentemente de serem nacionais ou locais da JT, e do valor do parâmetro descartar_movimentos_ausentes_de_para_cnj.

Foi incluído também um alerta no log no nível INFO caso o mapeador DE-PARA descarte o movimento do PJe.