### PR TITLE
Configuracao pom pasta resources jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,13 +116,44 @@
                 </configuration>
             </plugin>
             
-            <!-- Para incluir a pasta resources dentro da raiz no arquivo .JAR gerado -->
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <configuration>
-                    <outputDirectory> ${project.build.outputDirectory}\resources</outputDirectory>
-                </configuration>		
-            </plugin>
+			<!-- Para incluir a pasta resources dentro da raiz no arquivo .JAR gerado 
+				com exceção do arquivo de configuração do log4j, que deve estar na pasta 
+				raiz -->
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.outputDirectory}\src\main\resources</outputDirectory>
+					<resources>
+						<resource>
+							<directory>${basedir}/src/main/resources</directory>
+							<excludes>
+								<exclude>**/log4j2-test.xml</exclude>
+							</excludes>
+						</resource>
+					</resources>
+				</configuration>
+			</plugin>
+
+			<!-- Para copiar o arquivo de configuração de log para dentro da raiz 
+				no arquivo .JAR gerado -->
+			<plugin>
+				<groupId>com.coderplus.maven.plugins</groupId>
+				<artifactId>copy-rename-maven-plugin</artifactId>
+				<version>1.0</version>
+				<executions>
+					<execution>
+						<id>copy-file</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<sourceFile>src/main/resources/log4j2-test.xml</sourceFile>
+							<destinationFile>${project.build.outputDirectory}\log4j2-test.xml</destinationFile>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
 			<!-- Make this jar executable -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,13 +116,13 @@
                 </configuration>
             </plugin>
             
-            <!-- Para incluir a pasta resources dentro da pasta resources no arquivo .JAR gerado -->
+            <!-- Para incluir a pasta resources dentro da raiz no arquivo .JAR gerado -->
             <plugin>
-			    <artifactId>maven-resources-plugin</artifactId>
-			    <configuration>
-			        <outputDirectory> ${project.build.outputDirectory}\resources</outputDirectory>
-			    </configuration>		
-	    	</plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <outputDirectory> ${project.build.outputDirectory}\resources</outputDirectory>
+                </configuration>		
+            </plugin>
 
 			<!-- Make this jar executable -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,14 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
+            
+            <!-- Para incluir a pasta resources dentro da pasta resources no arquivo .JAR gerado -->
+            <plugin>
+			    <artifactId>maven-resources-plugin</artifactId>
+			    <configuration>
+			        <outputDirectory> ${project.build.outputDirectory}\resources</outputDirectory>
+			    </configuration>		
+	    	</plugin>
 
 			<!-- Make this jar executable -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,28 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>br.trt4.jus.br</groupId>
-  <artifactId>justica_em_numeros_2016</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <name>Justiça em Números 2016</name>
-  <description>Ferramenta para extrair, do PJe, os XMLs para o Selo Justiça em Números 2016 do CNJ</description>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-  
-  <dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>br.trt4.jus.br</groupId>
+	<artifactId>justica_em_numeros_2016</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Justiça em Números 2016</name>
+	<description>Ferramenta para extrair, do PJe, os XMLs para o Selo Justiça em Números 2016 do CNJ</description>
 
-		<!-- Ferramenta criada pelo TRT3 para fazer mapeamento DE-PARA de movimentos e complementos -->
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+
+		<!-- Ferramenta criada pelo TRT3 para fazer mapeamento DE-PARA de movimentos 
+			e complementos -->
 		<!-- Disponível em https://gitlab.trt15.jus.br/estatistica_cnj_jt/depara-jt-cnj -->
 		<dependency>
 			<groupId>br.jus.trt3</groupId>
 			<artifactId>depara-jt-cnj</artifactId>
 			<version>2.6</version>
 		</dependency>
-		
+
 		<!-- Utilizado para criar JAR com todas as dependências -->
 		<!-- https://mvnrepository.com/artifact/com.jolira/onejar-maven-plugin -->
 		<dependency>
@@ -27,45 +30,47 @@
 			<artifactId>onejar-maven-plugin</artifactId>
 			<version>1.4.4</version>
 		</dependency>
-  
-        <!-- Utilizado para conectar no banco de dados do PJe -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>9.4-1200-jdbc41</version>
-        </dependency>
-  
-        <!-- Utilizado como ferramenta auxiliar em diversas classes -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.8</version>
-        </dependency>
-    
-        <!-- Utilizado como ferramenta auxiliar em diversas classes -->
-        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.6</version>
-        </dependency>
-  
-        <!-- Utilizado para gerar arquivos ZIP com os dados que foram enviados ao CNJ, para backup -->
-        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-compress -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
-        </dependency>
-        
-        <!-- http://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-web -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
-        </dependency>
 
-        <!-- Utilizado pela classe Op_X_OperacaoCompleta para conferir os dados que foram enviados ao FTP do CNJ -->
+		<!-- Utilizado para conectar no banco de dados do PJe -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>9.4-1200-jdbc41</version>
+		</dependency>
+
+		<!-- Utilizado como ferramenta auxiliar em diversas classes -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.8</version>
+		</dependency>
+
+		<!-- Utilizado como ferramenta auxiliar em diversas classes -->
+		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.6</version>
+		</dependency>
+
+		<!-- Utilizado para gerar arquivos ZIP com os dados que foram enviados 
+			ao CNJ, para backup -->
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-compress -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.20</version>
+		</dependency>
+
+		<!-- http://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-web -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.13.3</version>
+		</dependency>
+
+		<!-- Utilizado pela classe Op_X_OperacaoCompleta para conferir os dados 
+			que foram enviados ao FTP do CNJ -->
 		<!-- https://mvnrepository.com/artifact/commons-net/commons-net -->
 		<dependency>
 			<groupId>commons-net</groupId>
@@ -77,45 +82,47 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<!-- Não utilizar 4.5.3: Antonio Lucas encontrou uma falha que causava erro no envio ao CNJ -->
+			<!-- Não utilizar 4.5.3: Antonio Lucas encontrou uma falha que causava 
+				erro no envio ao CNJ -->
 			<version>4.5.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<!-- Não utilizar 4.5.3: Antonio Lucas encontrou uma falha que causava erro no envio ao CNJ -->
+			<!-- Não utilizar 4.5.3: Antonio Lucas encontrou uma falha que causava 
+				erro no envio ao CNJ -->
 			<version>4.5.6</version>
 		</dependency>
-		
+
 		<!-- Utilizado para fazer validação prévia do XML -->
 		<dependency>
-		    <groupId>com.google.code.gson</groupId>
-		    <artifactId>gson</artifactId>
-		    <version>2.8.6</version>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.6</version>
 		</dependency>
-		
-        <!-- Utilizado por todos os testes unitários da ferramenta -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-        
-  </dependencies>
-  
-  <build>
-    <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            
+
+		<!-- Utilizado por todos os testes unitários da ferramenta -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.2</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>${project.build.sourceEncoding}</encoding>
+				</configuration>
+			</plugin>
+
 			<!-- Para incluir a pasta resources dentro da raiz no arquivo .JAR gerado 
 				com exceção do arquivo de configuração do log4j, que deve estar na pasta 
 				raiz -->
@@ -157,37 +164,37 @@
 
 			<!-- Make this jar executable -->
 			<plugin>
-			        <groupId>org.apache.maven.plugins</groupId>
-			        <artifactId>maven-jar-plugin</artifactId>
-			        <version>3.0.2</version>
-			        <configuration>
-			                <archive>
-			                        <manifest>
-			                                <mainClass>br.jus.trt4.justica_em_numeros_2016.auxiliar.MainClass</mainClass>
-			                        </manifest>
-			                </archive>
-			        </configuration>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>br.jus.trt4.justica_em_numeros_2016.auxiliar.MainClass</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
 			</plugin>
 
 
 
-		<!-- Utilizado para criar JAR com todas as dependências -->
-		<!-- Fonte: http://www.mkyong.com/maven/maven-create-a-fat-jar-file-one-jar-example/ -->
-		<plugin>
-		        <groupId>com.jolira</groupId>
-		        <artifactId>onejar-maven-plugin</artifactId>
-		        <version>1.4.4</version>
-		        <executions>
-		                <execution>
-		                        <goals>
-		                                <goal>one-jar</goal>
-		                        </goals>
-		                </execution>
-		        </executions>
-		</plugin>
+			<!-- Utilizado para criar JAR com todas as dependências -->
+			<!-- Fonte: http://www.mkyong.com/maven/maven-create-a-fat-jar-file-one-jar-example/ -->
+			<plugin>
+				<groupId>com.jolira</groupId>
+				<artifactId>onejar-maven-plugin</artifactId>
+				<version>1.4.4</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>one-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 
 
-    </plugins>
-  
-  </build>
+		</plugins>
+
+	</build>
 </project>

--- a/src/main/java/br/jus/trt4/justica_em_numeros_2016/auxiliar/Auxiliar.java
+++ b/src/main/java/br/jus/trt4/justica_em_numeros_2016/auxiliar/Auxiliar.java
@@ -23,6 +23,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -300,17 +302,20 @@ public class Auxiliar {
 	
 	
 	/**
-	 *  Carrega os dados de um arquivo ".properties", possibilitando que o parâmetro tipo_carga_xml seja
-	 *  passado como parâmetro da função, desconsiderando o que está no arquivo de propriedades.
+	 *  Carrega os dados de um arquivo ".properties", possibilitando que os parâmetros tipo_carga_xml e mes_ano_corte sejam
+	 *  passados como parâmetro da função, desconsiderando o que está no arquivo de propriedades.
 	 *  Esse método visa possibilitar a execução automatizada do extrator por linha de comando, evitando que seja necessário
 	 *  alterar o arquivo de propriedades indicando a competência de cada remessa mensal.
 
 	 * @param tipoCargaXml Tipo de carga em que os processos serão extraídos, podendo ser COMPLETA, MENSAL, 
 	 * 					   TODOS_COM_MOVIMENTACOES, TESTES e PROCESSO.
+	 * @param mesAnoCorte String no formato YYYY-MM, em que o ano pode ter os valores entre 2000 e 2049 e o mês entre 01 e 12
 	 */
-	public static void carregarPropertiesDoArquivo(String tipoCargaXml) {
+	public static void carregarPropertiesDoArquivo(String tipoCargaXml, String mesAnoCorte) {
 		
 		final String ParametroTipoCargaXml = "tipo_carga_xml";
+		final String ParametroMesAnoCorte = "mes_ano_corte";
+		final Pattern padraoMesAnoCorte = Pattern.compile("^20[0-4]\\d[-](0[1-9]|1[0-2])$"); 
 		
 		if (configs == null) {
 			configs = getConfigs();
@@ -318,6 +323,14 @@ public class Auxiliar {
 		
 		if(tipoCargaXml != null && tipoCargaXml.length() > 0) {
 			configs.setProperty(ParametroTipoCargaXml, tipoCargaXml);			
+		}
+		
+		if(mesAnoCorte != null && padraoMesAnoCorte.matcher(mesAnoCorte).find()) {
+			configs.setProperty(ParametroMesAnoCorte, mesAnoCorte);			
+		} else {
+			//Nesse momento, é melhor não utilizar o LOGGER, pois ele ainda não está configurado para gravar na pasta correta (dentro de "output")
+			System.out.println("O valor atributo mes_ano_corte está nulo ou não foi conhecido. Será utilizado o dentro do arquivo config.properties."
+					+ "  Valor dele: " + mesAnoCorte + ".");
 		}
 		
 	}

--- a/src/main/java/br/jus/trt4/justica_em_numeros_2016/auxiliar/MainClass.java
+++ b/src/main/java/br/jus/trt4/justica_em_numeros_2016/auxiliar/MainClass.java
@@ -13,13 +13,16 @@ import br.jus.trt4.justica_em_numeros_2016.tasks.Op_Y_OperacaoFluxoContinuo;
  * 
  * OPCIONALMENTE pode receber até três argumentos de execucação: 
  * 		1) Código da operação a ser executada
- * 		2) Tipo de carga XML , podendo ser COMPLETA, MENSAL, TODOS_COM_MOVIMENTACOES, TESTES e PROCESSO.  
- *		3) Caractere (S, N) indicando se as operações Op_4_ValidaEnviaArquivosCNJ e Op_5_ConfereProtocolosCNJ
- *		   serão reiniciadas caso aconteça algum erro. Valor padrão: S.
- *		4) Caractere (S, N) indicando se a operação Op_X_OperacaoCompleta deve continuar caso aconteça algum erro em quaisquer 
- *		   das operações. As operações 4 e 5 podem ser reiniciadas caso aconteça algum erro, porém os erros das operações anteriores
+ * 		2) Tipo de carga XML , podendo ser COMPLETA, MENSAL, TODOS_COM_MOVIMENTACOES, TESTES e PROCESSO.
+ *   	3) Mês e ano no formato YYYY-MM , indicando o período da carga mensal. O ano pode ter os valores entre 2000 e 2049 
+ *   	   e o mês entre 01 e 12. Se a carga for de outro tipo, pode preencher com qualquer valor em outro formato.
+ *		4) Caractere (S, N) indicando se as operações Op_4_ValidaEnviaArquivosCNJ e Op_5_ConfereProtocolosCNJ
+ *		   serão reiniciadas caso aconteça algum erro. Valor padrão: N.
+ *		5) Caractere (S, N) indicando se a operação Op_X_OperacaoCompleta deve continuar caso aconteça algum erro em quaisquer 
+ *		   das operações. Dessa forma se acontecer qualquer erro não impeditivo nas operações 1 e 2, o processo nunca será concluído.
+ *		   As operações 4 e 5 podem ser reiniciadas caso aconteça algum erro, porém os erros das operações anteriores
  *		   são considerados e farão com que essas operações nunca terminem, mesmo que não aconteça nenhum erro nelas.
- *		   Valor padrão: N.    
+ *		   Valor padrão: S.    
  * @see br.jus.trt4.justica_em_numeros_2016.auxiliar#carregarPropertiesDoArquivo(String)
  * 
  * @author felipe.giotto@trt4.jus.br
@@ -29,14 +32,16 @@ public class MainClass {
 	public static void main(String[] args) throws Exception {
 		String opcao;
 		String tipoCargaXml = null;
-		String reiniciarOperacaoEmCasoErro = "S";
-		String continuarOperacaoCompletaEmCasoErro = "N";
+		String mesAnoCorte = null;
+		String reiniciarOperacaoEmCasoErro = "N";
+		String continuarOperacaoCompletaEmCasoErro = "S";
 
 		if (args.length > 0) {
 			opcao = args[0];
 			tipoCargaXml = args.length > 1 ? args[1] : null;
-			reiniciarOperacaoEmCasoErro = args.length > 2 ? args[2] : "S";
-			continuarOperacaoCompletaEmCasoErro = args.length > 3 ? args[3] : "N";
+			mesAnoCorte = args.length > 2 ? args[2] : null;
+			reiniciarOperacaoEmCasoErro = args.length > 3 ? args[3] : "S";
+			continuarOperacaoCompletaEmCasoErro = args.length > 4 ? args[4] : "N";
 		} else {
 			System.out.println("Digite código da operação a ser executada:");
 			System.out.println("1: BaixaListaDeNumerosDeProcessos");
@@ -50,8 +55,8 @@ public class MainClass {
 			opcao = Auxiliar.readStdin().toUpperCase();
 		}
 		
-		//Permite que o parâmetro tipo_carga_xml seja passado pela linha de comando, desconsiderando o que estiver no arquivo .properties 
-		Auxiliar.carregarPropertiesDoArquivo(tipoCargaXml);
+		//Permite que os parâmetros tipo_carga_xml e mes_ano_corte sejas passados pela linha de comando, desconsiderando o que estiver no arquivo .properties 
+		Auxiliar.carregarPropertiesDoArquivo(tipoCargaXml, mesAnoCorte);
 
 		switch (opcao) {
 		case "1":


### PR DESCRIPTION
Alterações para incluir a pasta resources dentro do arquivo .JAR gerado.

Apesar de o arquivo ser quase totalmente alterado pela correção automática de identação pelo eclipse, as alterações efetivas foram apenas na inclusão dos plugins maven-resources-plugin e copy-rename-maven-plugin, que podem ser vistas no [antepenúltimo commit](https://github.com/felipegiotto/justica_em_numeros_2016/pull/50/commits/bfa2d611f6f42d148193097c434ae283192b92d6). O [penúltimo commit](https://github.com/felipegiotto/justica_em_numeros_2016/pull/50/commits/e4267ae3e3c6fd2c52e9b525a2fe43a711758143) foi apenas para corrigir a identação.